### PR TITLE
Fix Build on Linux When Not Using Plugins

### DIFF
--- a/nativeshell_build/src/artifacts_emitter.rs
+++ b/nativeshell_build/src/artifacts_emitter.rs
@@ -115,7 +115,7 @@ impl<'a> ArtifactsEmitter<'a> {
         let artifacts_out_dir = {
             if cfg!(target_os = "linux") {
                 // RUNPATH is set to $origin/lib
-                self.artifacts_out_dir.join("lib")
+                mkdir(&self.artifacts_out_dir, Some("lib"))?
             } else {
                 self.artifacts_out_dir.clone()
             }


### PR DESCRIPTION
When compiling the template app I ran into an error on Linux that said the `libflutter_linux_gtk.so` symlink could not be created. The problem was just that the `target/debug/lib` dir needed to be created first. This change fixes that.

---

Great project BTW! This looks amazing and I'm very excited to try it out. I've been looking for a good way to hook Flutter up to Rust for making apps and the example app just worked right out-of-the box, which is pretty amazing.