### PR TITLE
Use weak references when passing context along.

### DIFF
--- a/nativeshell/src/error.rs
+++ b/nativeshell/src/error.rs
@@ -4,6 +4,7 @@ use crate::{codec::value::ValueError, shell::platform::error::PlatformError};
 
 #[derive(Debug, Clone)]
 pub enum Error {
+    InvalidContext,
     InvalidEngineHandle,
     Platform(PlatformError),
     Value(ValueError),
@@ -13,6 +14,9 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Error::InvalidContext => {
+                write!(f, "Context already destroyed")
+            }
             Error::Platform(error) => Display::fmt(error, f),
             Error::InvalidEngineHandle => {
                 write!(f, "Provided handle does not match any engine")

--- a/nativeshell/src/error.rs
+++ b/nativeshell/src/error.rs
@@ -15,7 +15,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::InvalidContext => {
-                write!(f, "Context already destroyed")
+                write!(f, "Context was already destroyed")
             }
             Error::Platform(error) => Display::fmt(error, f),
             Error::InvalidEngineHandle => {

--- a/nativeshell/src/shell/context.rs
+++ b/nativeshell/src/shell/context.rs
@@ -97,7 +97,7 @@ impl Context {
 }
 
 // Strong reference to a Context. Intentionally not clonable; There should be one
-// "master" reference and all other should be used just locally
+// "master" reference and all other should be used just locally.
 pub struct ContextRef {
     context: Rc<ContextImpl>,
 }

--- a/nativeshell/src/shell/context.rs
+++ b/nativeshell/src/shell/context.rs
@@ -53,19 +53,19 @@ impl ContextImpl {
 
     fn initialize(&self, context: &ContextRef) -> Result<()> {
         self.run_loop.set(RunLoop::new());
-        self.engine_manager.set(EngineManager::new(&context));
-        self.message_manager.set(MessageManager::new(&context));
+        self.engine_manager.set(EngineManager::new(context));
+        self.message_manager.set(MessageManager::new(context));
         self.window_method_channel
             .set(WindowMethodChannel::new(&context));
-        self.window_manager.set(WindowManager::new(&context));
-        self.menu_manager.set(MenuManager::new(&context));
+        self.window_manager.set(WindowManager::new(context));
+        self.menu_manager.set(MenuManager::new(context));
 
         #[cfg(debug_assertions)]
         {
             self.sponsor_prompt();
         }
 
-        init_platform(&context).map_err(Error::from)?;
+        init_platform(context).map_err(Error::from)?;
 
         Ok(())
     }

--- a/nativeshell/src/shell/context.rs
+++ b/nativeshell/src/shell/context.rs
@@ -81,6 +81,7 @@ impl ContextImpl {
     }
 }
 
+// Non owning cloneable reference to a Context. Call Context::get() to access the context.
 #[derive(Clone)]
 pub struct Context {
     context: Weak<ContextImpl>,
@@ -97,12 +98,13 @@ impl Context {
 }
 
 // Strong reference to a Context. Intentionally not clonable; There should be one
-// "master" reference and all other should be used just locally.
+// "master" owning reference and all other instances should be used just locally.
+// If you need to pass the context along, use weak() to get weak reference and pass that.
 pub struct ContextRef {
     context: Rc<ContextImpl>,
 }
 
-impl<'a> ContextRef {
+impl ContextRef {
     pub fn weak(&self) -> Context {
         Context {
             context: Rc::downgrade(&self.context),

--- a/nativeshell/src/shell/context.rs
+++ b/nativeshell/src/shell/context.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 use crate::{util::LateRefCell, Error, Result};
 
@@ -10,7 +10,7 @@ use super::{
 pub struct ContextOptions {
     pub app_namespace: String,
     pub flutter_plugins: Vec<PlatformPlugin>,
-    pub on_last_engine_removed: Box<dyn Fn(Rc<Context>)>,
+    pub on_last_engine_removed: Box<dyn Fn(&ContextRef)>,
     pub custom_drag_data_adapters: Vec<Box<dyn DragDataAdapter>>,
 }
 
@@ -25,7 +25,7 @@ impl Default for ContextOptions {
     }
 }
 
-pub struct Context {
+pub struct ContextImpl {
     pub options: ContextOptions,
     pub run_loop: LateRefCell<RunLoop>,
     pub engine_manager: LateRefCell<EngineManager>,
@@ -35,8 +35,8 @@ pub struct Context {
     pub menu_manager: LateRefCell<MenuManager>,
 }
 
-impl Context {
-    pub fn new(options: ContextOptions) -> Result<Rc<Self>> {
+impl ContextImpl {
+    fn new(options: ContextOptions) -> Result<ContextRef> {
         let res = Rc::new(Self {
             options,
             run_loop: LateRefCell::new(),
@@ -46,26 +46,26 @@ impl Context {
             window_manager: LateRefCell::new(),
             menu_manager: LateRefCell::new(),
         });
-        res.initialize(res.clone())?;
+        let res = ContextRef { context: res };
+        res.initialize(&res)?;
         Ok(res)
     }
 
-    fn initialize(&self, context: Rc<Context>) -> Result<()> {
+    fn initialize(&self, context: &ContextRef) -> Result<()> {
         self.run_loop.set(RunLoop::new());
-        self.engine_manager.set(EngineManager::new(context.clone()));
-        self.message_manager
-            .set(MessageManager::new(context.clone()));
+        self.engine_manager.set(EngineManager::new(&context));
+        self.message_manager.set(MessageManager::new(&context));
         self.window_method_channel
-            .set(WindowMethodChannel::new(context.clone()));
-        self.window_manager.set(WindowManager::new(context.clone()));
-        self.menu_manager.set(MenuManager::new(context.clone()));
+            .set(WindowMethodChannel::new(&context));
+        self.window_manager.set(WindowManager::new(&context));
+        self.menu_manager.set(MenuManager::new(&context));
 
         #[cfg(debug_assertions)]
         {
             self.sponsor_prompt();
         }
 
-        init_platform(context).map_err(Error::from)?;
+        init_platform(&context).map_err(Error::from)?;
 
         Ok(())
     }
@@ -78,5 +78,42 @@ impl Context {
             println!("** We have a long way to go: https://nativeshell.dev/roadmap");
             println!();
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct Context {
+    context: Weak<ContextImpl>,
+}
+
+impl Context {
+    pub fn new(options: ContextOptions) -> Result<ContextRef> {
+        ContextImpl::new(options)
+    }
+
+    pub fn get(&self) -> Option<ContextRef> {
+        return self.context.upgrade().map(|c| ContextRef { context: c });
+    }
+}
+
+// Strong reference to a Context. Intentionally not clonable; There should be one
+// "master" reference and all other should be used just locally
+pub struct ContextRef {
+    context: Rc<ContextImpl>,
+}
+
+impl<'a> ContextRef {
+    pub fn weak(&self) -> Context {
+        Context {
+            context: Rc::downgrade(&self.context),
+        }
+    }
+}
+
+impl std::ops::Deref for ContextRef {
+    type Target = ContextImpl;
+
+    fn deref(&self) -> &ContextImpl {
+        self.context.deref()
     }
 }

--- a/nativeshell/src/shell/platform/linux/init.rs
+++ b/nativeshell/src/shell/platform/linux/init.rs
@@ -1,13 +1,13 @@
-use std::rc::{Rc, Weak};
+use std::rc::Weak;
 
 use gdk::{Event, WindowExt};
 use glib::ObjectExt;
 
-use crate::shell::{platform::window::PlatformWindow, Context};
+use crate::shell::{platform::window::PlatformWindow, ContextRef};
 
 use super::error::{PlatformError, PlatformResult};
 
-pub fn init_platform(_context: Rc<Context>) -> PlatformResult<()> {
+pub fn init_platform(_context: &ContextRef) -> PlatformResult<()> {
     gtk::init().map_err(|e| PlatformError::GLibError {
         message: e.message.into(),
     })?;

--- a/nativeshell/src/shell/platform/linux/menu.rs
+++ b/nativeshell/src/shell/platform/linux/menu.rs
@@ -491,7 +491,7 @@ impl PlatformMenu {
 pub struct PlatformMenuManager {}
 
 impl PlatformMenuManager {
-    pub fn new(_context: Rc<Context>) -> Self {
+    pub fn new(_context: Context) -> Self {
         Self {}
     }
 

--- a/nativeshell/src/shell/platform/macos/init.rs
+++ b/nativeshell/src/shell/platform/macos/init.rs
@@ -1,9 +1,7 @@
-use std::rc::Rc;
-
-use crate::shell::Context;
+use crate::shell::ContextRef;
 
 use super::error::PlatformResult;
 
-pub fn init_platform(_context: Rc<Context>) -> PlatformResult<()> {
+pub fn init_platform(_context: &ContextRef) -> PlatformResult<()> {
     Ok(())
 }

--- a/nativeshell/src/shell/platform/null/init.rs
+++ b/nativeshell/src/shell/platform/null/init.rs
@@ -1,9 +1,7 @@
-use std::rc::Rc;
-
-use crate::shell::Context;
+use crate::shell::ContextRef;
 
 use super::error::PlatformResult;
 
-pub fn init_platform(_context: Rc<Context>) -> PlatformResult<()> {
+pub fn init_platform(_context: &ContextRef) -> PlatformResult<()> {
     Ok(())
 }

--- a/nativeshell/src/shell/platform/null/menu.rs
+++ b/nativeshell/src/shell/platform/null/menu.rs
@@ -8,7 +8,7 @@ pub struct PlatformMenu {}
 
 #[allow(unused_variables)]
 impl PlatformMenu {
-    pub fn new(context: Rc<Context>, handle: MenuHandle) -> Self {
+    pub fn new(context: Context, handle: MenuHandle) -> Self {
         Self {}
     }
 
@@ -22,7 +22,7 @@ impl PlatformMenu {
 pub struct PlatformMenuManager {}
 
 impl PlatformMenuManager {
-    pub fn new(context: Rc<Context>) -> Self {
+    pub fn new(context: Context) -> Self {
         Self {}
     }
 

--- a/nativeshell/src/shell/platform/null/window.rs
+++ b/nativeshell/src/shell/platform/null/window.rs
@@ -24,7 +24,7 @@ pub struct PlatformWindow {}
 #[allow(unused_variables)]
 impl PlatformWindow {
     pub fn new(
-        context: Rc<Context>,
+        context: Context,
         delegate: Weak<dyn PlatformWindowDelegate>,
         parent: Option<Rc<PlatformWindow>>,
     ) -> Self {

--- a/nativeshell/src/shell/platform/win32/init.rs
+++ b/nativeshell/src/shell/platform/win32/init.rs
@@ -1,6 +1,6 @@
-use std::{ptr::null_mut, rc::Rc};
+use std::ptr::null_mut;
 
-use crate::shell::Context;
+use crate::shell::ContextRef;
 
 use super::{
     all_bindings::*,
@@ -10,7 +10,7 @@ use super::{
     util::{direct_composition_supported, HRESULTExt},
 };
 
-pub fn init_platform(_context: Rc<Context>) -> PlatformResult<()> {
+pub fn init_platform(_context: &ContextRef) -> PlatformResult<()> {
     unsafe {
         // Angle will try opening these with GetModuleHandleEx, which means they need to be
         // loaded first; Otherwise it falls back to d3dcompiler_47, which is not present on

--- a/nativeshell/src/shell/platform/win32/menu.rs
+++ b/nativeshell/src/shell/platform/win32/menu.rs
@@ -27,7 +27,7 @@ pub struct PlatformMenu {
 pub struct PlatformMenuManager {}
 
 impl PlatformMenuManager {
-    pub fn new(_context: Rc<Context>) -> Self {
+    pub fn new(_context: Context) -> Self {
         Self {}
     }
 
@@ -37,7 +37,7 @@ impl PlatformMenuManager {
 }
 
 impl PlatformMenu {
-    pub fn new(_context: Rc<Context>, handle: MenuHandle) -> Self {
+    pub fn new(_context: Context, handle: MenuHandle) -> Self {
         let menu = unsafe {
             let menu = CreatePopupMenu();
 


### PR DESCRIPTION
Otherwise the context is never dropped.