### PR TITLE
Allows specifying custom Flutter location

### DIFF
--- a/nativeshell_build/src/artifacts_emitter.rs
+++ b/nativeshell_build/src/artifacts_emitter.rs
@@ -231,7 +231,7 @@ impl<'a> ArtifactsEmitter<'a> {
         Self::find_flutter_bin().map(|p| p.join("cache").join("artifacts").join("engine"))
     }
 
-    fn find_local_engine_src_path() -> Option<PathBuf> {
+    pub(super) fn find_local_engine_src_path() -> Option<PathBuf> {
         Self::find_flutter_bin()
             .and_then(|p| {
                 p.parent()

--- a/nativeshell_build/src/artifacts_emitter.rs
+++ b/nativeshell_build/src/artifacts_emitter.rs
@@ -34,7 +34,7 @@ impl<'a> ArtifactsEmitter<'a> {
         let data_dir = self.artifacts_out_dir.join("data");
         if data_dir.exists() {
             std::fs::remove_dir_all(&data_dir)
-                .unwrap_or_else(|_| panic!("Failed to remove {:?}", data_dir));
+                .wrap_error(FileOperation::RemoveDir, || data_dir.clone())?;
         }
         let assets_dst_dir = mkdir(&data_dir, Some("flutter_assets"))?;
         let assets_src_dir = {

--- a/nativeshell_build/src/error.rs
+++ b/nativeshell_build/src/error.rs
@@ -6,6 +6,7 @@ pub enum FileOperation {
     Copy,
     Move,
     Remove,
+    RemoveDir,
     Read,
     Write,
     Open,

--- a/nativeshell_build/src/error.rs
+++ b/nativeshell_build/src/error.rs
@@ -28,6 +28,11 @@ pub enum BuildError {
         stderr: String,
         stdout: String,
     },
+    FlutterNotFoundError,
+    FlutterPathInvalidError {
+        path: PathBuf,
+    },
+    FlutterLocalEngineNotFound,
     FileOperationError {
         operation: FileOperation,
         path: PathBuf,
@@ -94,6 +99,29 @@ impl Display for BuildError {
             }
             BuildError::OtherError(err) => {
                 write!(f, "{}", err)
+            }
+            BuildError::FlutterNotFoundError => {
+                write!(
+                    f,
+                    "Couldn't find Flutter installation. \
+                    Plase make sure 'flutter' executable is in PATH \
+                    or specify 'flutter_path' in FlutterOptions"
+                )
+            }
+            BuildError::FlutterPathInvalidError { path } => {
+                write!(
+                    f,
+                    "Flutter path {:?} does not point to a valid flutter installation",
+                    path
+                )
+            }
+            BuildError::FlutterLocalEngineNotFound => {
+                write!(
+                    f,
+                    "Could not find path for local Flutter engine. Either specify a valid \
+                        'local_engine_src_path', or make sure that engine project exists \
+                        alongside the Flutter project."
+                )
             }
         }
     }

--- a/nativeshell_build/src/flutter_build.rs
+++ b/nativeshell_build/src/flutter_build.rs
@@ -23,7 +23,15 @@ pub struct FlutterOptions {
     // lib/main.dart by default
     pub target_file: PathBuf,
 
+    // Custom Flutter location. If not specified, NativeShell build will try to find
+    // flutter executable in PATH and derive the location from there.
+    pub flutter_path: Option<PathBuf>,
+
+    // Name of local engine
     pub local_engine: Option<String>,
+
+    // Source path of local engine. If not specified, NativeShell will try to locate
+    // it relative to flutter path.
     pub local_engine_src_path: Option<PathBuf>,
 }
 
@@ -31,6 +39,7 @@ impl Default for FlutterOptions {
     fn default() -> Self {
         Self {
             target_file: "lib/main.dart".into(),
+            flutter_path: None,
             local_engine: None,
             local_engine_src_path: None,
         }
@@ -38,35 +47,58 @@ impl Default for FlutterOptions {
 }
 
 impl FlutterOptions {
-    pub(super) fn find_flutter_executable(&self) -> Option<PathBuf> {
+    pub(super) fn find_flutter_executable(&self) -> BuildResult<PathBuf> {
         let executable = if cfg!(target_os = "windows") {
             "flutter.bat"
         } else {
             "flutter"
         };
-        find_executable(executable)
-            .and_then(|p| p.canonicalize().map(|p| simplified(&p).into()).ok())
+        match &self.flutter_path {
+            Some(path) => {
+                let out_dir: PathBuf = std::env::var("CARGO_MANIFEST_DIR").unwrap().into();
+                let path = out_dir.join(path);
+                let executable = path.join("bin").join(executable);
+                if executable.exists() {
+                    Ok(executable)
+                } else {
+                    Err(BuildError::FlutterPathInvalidError { path: path.into() })
+                }
+            }
+            None => {
+                let executable =
+                    find_executable(executable).ok_or(BuildError::FlutterNotFoundError)?;
+                let executable = executable
+                    .canonicalize()
+                    .wrap_error(FileOperation::Canonicalize, || executable)?;
+                Ok(executable)
+            }
+        }
     }
 
-    pub(super) fn find_flutter_bin(&self) -> Option<PathBuf> {
-        self.find_flutter_executable()
-            .and_then(|p| p.parent().map(Path::to_owned))
+    pub(super) fn find_flutter_bin(&self) -> BuildResult<PathBuf> {
+        let executable = self.find_flutter_executable()?;
+        Ok(executable.parent().unwrap().into())
     }
 
-    pub(super) fn local_engine_src_path(&self) -> Option<PathBuf> {
-        self.local_engine_src_path
-            .clone()
-            .or_else(|| self.find_local_engine_src_path())
+    pub(super) fn local_engine_src_path(&self) -> BuildResult<PathBuf> {
+        match &self.local_engine_src_path {
+            Some(path) => Ok(path.clone()),
+            None => self.find_local_engine_src_path(),
+        }
     }
 
-    fn find_local_engine_src_path(&self) -> Option<PathBuf> {
-        self.find_flutter_bin()
-            .and_then(|p| {
-                p.parent()
-                    .map(Path::to_owned)
-                    .and_then(|p| p.parent().map(Path::to_owned))
-            })
-            .map(|p| p.join("engine").join("src"))
+    fn find_local_engine_src_path(&self) -> BuildResult<PathBuf> {
+        let bin = self.find_flutter_bin()?;
+        let path = bin
+            .parent()
+            .and_then(|p| p.parent())
+            .map(|p| p.join("engine").join("src"));
+        if let Some(path) = path {
+            if path.exists() {
+                return Ok(path);
+            }
+        }
+        Err(BuildError::FlutterLocalEngineNotFound)
     }
 }
 
@@ -328,10 +360,7 @@ impl Flutter {
     }
 
     fn create_flutter_command(&self) -> BuildResult<Command> {
-        let executable = self.options.find_flutter_executable();
-        let executable = executable.ok_or(BuildError::OtherError(
-            "Couldn't find flutter executable".into(),
-        ))?;
+        let executable = self.options.find_flutter_executable()?;
         if cfg!(target_os = "windows") {
             let mut c = Command::new("cmd");
             c.arg("/C").arg(executable);
@@ -375,13 +404,10 @@ impl Flutter {
         if let Some(local_engine) = &self.options.local_engine {
             command.arg(format!("--local-engine={}", local_engine));
 
-            let src_path = &self.options.local_engine_src_path();
-            if let Some(src_path) = src_path {
-                command.arg(format!(
-                    "--local-engine-src-path={}",
-                    src_path.to_slash_lossy()
-                ));
-            }
+            command.arg(format!(
+                "--local-engine-src-path={}",
+                self.options.local_engine_src_path()?.to_slash_lossy()
+            ));
         }
         command
             .arg("assemble")
@@ -494,8 +520,7 @@ impl Flutter {
         }
         let engine_version = self
             .options
-            .find_flutter_bin()
-            .ok_or_else(|| BuildError::OtherError("Couldn't find Flutter installation".into()))?
+            .find_flutter_bin()?
             .join("internal")
             .join("engine.version");
 

--- a/nativeshell_build/src/flutter_build.rs
+++ b/nativeshell_build/src/flutter_build.rs
@@ -70,6 +70,7 @@ impl FlutterOptions {
                 let executable = executable
                     .canonicalize()
                     .wrap_error(FileOperation::Canonicalize, || executable)?;
+                let executable = simplified(&&executable).into();
                 Ok(executable)
             }
         }

--- a/nativeshell_build/src/flutter_build.rs
+++ b/nativeshell_build/src/flutter_build.rs
@@ -44,7 +44,8 @@ impl FlutterOptions {
         } else {
             "flutter"
         };
-        find_executable(executable).and_then(|p| p.canonicalize().ok())
+        find_executable(executable)
+            .and_then(|p| p.canonicalize().map(|p| simplified(&p).into()).ok())
     }
 
     pub(super) fn find_flutter_bin(&self) -> Option<PathBuf> {

--- a/nativeshell_build/src/flutter_build.rs
+++ b/nativeshell_build/src/flutter_build.rs
@@ -337,12 +337,18 @@ impl Flutter {
 
         if let Some(local_engine) = &self.options.local_engine {
             command.arg(format!("--local-engine={}", local_engine));
-        }
-        if let Some(local_src_engine_path) = &self.options.local_engine_src_path {
-            command.arg(format!(
-                "--local-engine-src-path={}",
-                local_src_engine_path.to_str().unwrap()
-            ));
+
+            let src_path = &self
+                .options
+                .local_engine_src_path
+                .clone()
+                .or_else(ArtifactsEmitter::find_local_engine_src_path);
+            if let Some(src_path) = src_path {
+                command.arg(format!(
+                    "--local-engine-src-path={}",
+                    src_path.to_slash_lossy()
+                ));
+            }
         }
         command
             .arg("assemble")

--- a/nativeshell_build/src/macos_bundle.rs
+++ b/nativeshell_build/src/macos_bundle.rs
@@ -63,7 +63,7 @@ impl MacOSBundle {
 
         if bundle_path.exists() {
             std::fs::remove_dir_all(&bundle_path)
-                .unwrap_or_else(|_| panic!("Failed to remove {:?}", bundle_path));
+                .wrap_error(FileOperation::RemoveDir, || bundle_path.clone())?;
         }
 
         mkdir::<_, PathBuf>(&bundle_path, None)?;

--- a/nativeshell_build/src/util.rs
+++ b/nativeshell_build/src/util.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     fs::{self, canonicalize},
     path::{Path, PathBuf},
     process::Command,
@@ -142,4 +143,19 @@ where
 {
     let file_name = src.as_ref().file_name().unwrap();
     copy(&src, dst.as_ref().join(file_name), allow_symlinks)
+}
+
+pub(super) fn find_executable<P: AsRef<Path>>(exe_name: P) -> Option<PathBuf> {
+    env::var_os("PATH").and_then(|paths| {
+        env::split_paths(&paths)
+            .filter_map(|dir| {
+                let full_path = dir.join(&exe_name);
+                if full_path.is_file() {
+                    Some(full_path)
+                } else {
+                    None
+                }
+            })
+            .next()
+    })
 }

--- a/nativeshell_build/src/util.rs
+++ b/nativeshell_build/src/util.rs
@@ -81,12 +81,23 @@ pub(super) fn run_command(mut command: Command, command_name: &str) -> BuildResu
         .output()
         .wrap_error(FileOperation::Command, || command_name.into())?;
 
-    if !output.status.success() {
+    #[allow(unused_mut)]
+    let mut success = output.status.success();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // on windows we run flutter.bat through cmd /c, which unfortunately swallows
+    // the error code; So instead we check the output
+    #[cfg(target_os = "windows")]
+    {
+        if command_name == "flutter" {
+            success = stdout.trim_end().ends_with("exiting with code 0")
+        }
+    }
+    if !success {
         Err(BuildError::ToolError {
             command: format!("{:?}", command),
             status: output.status,
             stderr: String::from_utf8_lossy(&output.stderr).into(),
-            stdout: String::from_utf8_lossy(&output.stdout).into(),
+            stdout: stdout.into(),
         })
     } else {
         Ok(())


### PR DESCRIPTION
Currently NativeShell determines Flutter location by looking for flutter executable in PATH. This PR introduces a `flutter_path` option that can be used to override this behavior and specify Flutter location manually (either as absolute path or relative to cargo manifest.