### PR TITLE
Make MethodInvokerProvider returned invoker non optional

### DIFF
--- a/nativeshell/src/shell/keyboard_map_manager.rs
+++ b/nativeshell/src/shell/keyboard_map_manager.rs
@@ -81,15 +81,14 @@ impl KeyboardMapDelegate for KeyboardMapManager {
         let layout = self.platform_map.get_current_map();
         let layout = to_value(layout).unwrap();
         for engine in &self.engines {
-            if let Some(invoker) = self.provider.get_method_invoker_for_engine(*engine) {
-                invoker
-                    .call_method(
-                        method::keyboard_map::ON_CHANGED.into(),
-                        layout.clone(),
-                        |_| {},
-                    )
-                    .ok_log();
-            }
+            let invoker = self.provider.get_method_invoker_for_engine(*engine);
+            invoker
+                .call_method(
+                    method::keyboard_map::ON_CHANGED.into(),
+                    layout.clone(),
+                    |_| {},
+                )
+                .ok_log();
         }
     }
 }

--- a/nativeshell/src/shell/menu_manager.rs
+++ b/nativeshell/src/shell/menu_manager.rs
@@ -97,7 +97,7 @@ impl MenuManager {
     }
 
     fn invoker_for_menu(&self, menu_handle: MenuHandle) -> Option<MethodInvoker<Value>> {
-        self.platform_menu_map.get(&menu_handle).and_then(|e| {
+        self.platform_menu_map.get(&menu_handle).map(|e| {
             self.invoker_provider
                 .get_method_invoker_for_engine(e.engine)
         })

--- a/nativeshell/src/shell/method_channel.rs
+++ b/nativeshell/src/shell/method_channel.rs
@@ -3,7 +3,7 @@ use std::{
     rc::{Rc, Weak},
 };
 
-use crate::codec::{MethodCall, MethodCallReply, MethodInvoker, Value};
+use crate::codec::{MethodCall, MethodCallReply, MethodInvoker, StandardMethodCodec, Value};
 
 use super::{Context, EngineHandle, Handle};
 
@@ -14,16 +14,13 @@ pub struct MethodInvokerProvider {
 }
 
 impl MethodInvokerProvider {
-    pub fn get_method_invoker_for_engine(
-        &self,
-        handle: EngineHandle,
-    ) -> Option<MethodInvoker<Value>> {
-        self.context.get().map(|context| {
-            context
-                .message_manager
-                .borrow()
-                .get_method_invoker(handle, &self.channel)
-        })
+    pub fn get_method_invoker_for_engine(&self, handle: EngineHandle) -> MethodInvoker<Value> {
+        MethodInvoker::new(
+            self.context.clone(),
+            handle,
+            self.channel.clone(),
+            &StandardMethodCodec,
+        )
     }
 }
 


### PR DESCRIPTION
There's no point returning `None` instead of invoker if engine doesn't exist, because the engine may disappear later while invoker is still alive anyway. Missing engine can be detected as error code from `MethodInvoker::call_method`.