### PR TITLE
Allow using PhysicalKeys when specifying accelerators

### DIFF
--- a/nativeshell/src/shell/api_model.rs
+++ b/nativeshell/src/shell/api_model.rs
@@ -332,6 +332,7 @@ pub struct Key {
     pub logical_shift: Option<i64>,
     pub logical_alt: Option<i64>,
     pub logical_alt_shift: Option<i64>,
+    pub logical_meta: Option<i64>,
 }
 
 #[derive(serde::Serialize, Debug, Clone)]

--- a/nativeshell/src/shell/platform/linux/keyboard_map.rs
+++ b/nativeshell/src/shell/platform/linux/keyboard_map.rs
@@ -255,6 +255,7 @@ impl PlatformKeyboardMap {
     }
 
     fn on_layout_changed(&self) {
+        self.current_layout.borrow_mut().take();
         if let Some(delegate) = self.delegate.upgrade() {
             delegate.borrow().keyboard_map_did_change();
         }

--- a/nativeshell/src/shell/platform/linux/keyboard_map.rs
+++ b/nativeshell/src/shell/platform/linux/keyboard_map.rs
@@ -177,6 +177,7 @@ impl PlatformKeyboardMap {
             logical_shift: key_shift,
             logical_alt: None,
             logical_alt_shift: None,
+            logical_meta: None,
         }
     }
 
@@ -194,6 +195,7 @@ impl PlatformKeyboardMap {
             logical_shift: entry.fallback.and_then(Self::shift_key),
             logical_alt: None,
             logical_alt_shift: None,
+            logical_meta: None,
         }
     }
 

--- a/nativeshell/src/shell/platform/linux/menu.rs
+++ b/nativeshell/src/shell/platform/linux/menu.rs
@@ -360,10 +360,10 @@ impl PlatformMenu {
             "space" => gdk_sys::GDK_KEY_space,
             "tab" => gdk_sys::GDK_KEY_Tab,
             "enter" => gdk_sys::GDK_KEY_KP_Enter,
-            "up arrow" => gdk_sys::GDK_KEY_Up,
-            "down arrow" => gdk_sys::GDK_KEY_Down,
-            "left arrow" => gdk_sys::GDK_KEY_Left,
-            "right arrow" => gdk_sys::GDK_KEY_Right,
+            "arrow up" => gdk_sys::GDK_KEY_Up,
+            "arrow down" => gdk_sys::GDK_KEY_Down,
+            "arrow left" => gdk_sys::GDK_KEY_Left,
+            "arrow right" => gdk_sys::GDK_KEY_Right,
             _ => label.chars().next().unwrap_or(0 as char) as i32,
         };
         value

--- a/nativeshell/src/shell/platform/macos/keyboard_map.rs
+++ b/nativeshell/src/shell/platform/macos/keyboard_map.rs
@@ -211,6 +211,7 @@ impl PlatformKeyboardMap {
     }
 
     fn on_layout_changed(&self) {
+        self.current_layout.borrow_mut().take();
         if let Some(delegate) = self.delegate.upgrade() {
             delegate.borrow().keyboard_map_did_change();
         }

--- a/nativeshell/src/shell/platform/macos/keyboard_map_sys.rs
+++ b/nativeshell/src/shell/platform/macos/keyboard_map_sys.rs
@@ -10,7 +10,7 @@ extern "C" {
     pub static kTISPropertyUnicodeKeyLayoutData: CFObject;
     pub static kTISNotifySelectedKeyboardInputSourceChanged: CFStringRef;
     pub fn TISCopyCurrentKeyboardLayoutInputSource() -> CFObject;
-    pub fn TISCopyCurrentASCIICapableKeyboardInputSource() -> CFObject;
+    pub fn TISCopyCurrentASCIICapableKeyboardLayoutInputSource() -> CFObject;
     pub fn TISGetInputSourceProperty(input_source: CFObject, property_key: CFObject)
         -> *mut c_void;
 
@@ -67,6 +67,8 @@ pub const kUCKeyActionDisplay: u16 = 3;
 pub const kUCKeyTranslateNoDeadKeysBit: u32 = 0;
 #[allow(non_upper_case_globals)]
 pub const kUCKeyTranslateNoDeadKeysMask: u32 = 1 << kUCKeyTranslateNoDeadKeysBit;
+#[allow(non_upper_case_globals)]
+pub const cmdKey: u32 = 256;
 #[allow(non_upper_case_globals)]
 pub const shiftKey: u32 = 512;
 #[allow(non_upper_case_globals)]

--- a/nativeshell/src/shell/platform/macos/menu.rs
+++ b/nativeshell/src/shell/platform/macos/menu.rs
@@ -419,10 +419,10 @@ impl PlatformMenu {
             "space" => 0x0020,
             "tab" => 0x0009,
             "enter" => 0x000d,
-            "up arrow" => 0xF700,
-            "down arrow" => 0xF701,
-            "left arrow" => 0xF702,
-            "right arrow" => 0xF703,
+            "arrow up" => 0xF700,
+            "arrow down" => 0xF701,
+            "arrow left" => 0xF702,
+            "arrow right" => 0xF703,
             _ => label.chars().next().unwrap_or(0 as char) as u32,
         };
         let mut res = String::new();

--- a/nativeshell/src/shell/platform/win32/keyboard_map.rs
+++ b/nativeshell/src/shell/platform/win32/keyboard_map.rs
@@ -180,6 +180,7 @@ impl PlatformKeyboardMap {
             logical_shift: None,
             logical_alt: None,
             logical_alt_shift: None,
+            logical_meta: None,
         };
 
         let virtual_code = MapVirtualKeyW(entry.platform as u32, MAPVK_VSC_TO_VK);

--- a/nativeshell_dart/lib/src/accelerator.dart
+++ b/nativeshell_dart/lib/src/accelerator.dart
@@ -7,10 +7,16 @@ import 'menu.dart';
 class AcceleratorKey {
   AcceleratorKey(this.key, this.label);
 
-  final LogicalKeyboardKey key;
+  final KeyboardKey key;
   final String label;
 }
 
+// Defines a keyboard shortcut.
+// Can be conveniently constructed:
+//
+// import 'package:nativeshell/accelerators.dart';
+// final accelerator1 = cmdOrCtrl + shift + 'e';
+// final accelerator2 = alt + f1;
 class Accelerator {
   const Accelerator({
     this.key,
@@ -68,8 +74,10 @@ class Accelerator {
   bool matches(RawKeyEvent event) {
     final key = this.key?.key;
     if (key != null) {
-      final physicalKey =
-          KeyboardMap.current().getPhysicalKeyForLogicalKey(key);
+      final physicalKey = key is PhysicalKeyboardKey
+          ? key
+          : KeyboardMap.current()
+              .getPhysicalKeyForLogicalKey(key as LogicalKeyboardKey);
       return event.isAltPressed == alt &&
           event.isControlPressed == control &&
           event.isMetaPressed == meta &&

--- a/nativeshell_dart/lib/src/accelerator.dart
+++ b/nativeshell_dart/lib/src/accelerator.dart
@@ -30,7 +30,12 @@ class Accelerator {
     if (k is LogicalKeyboardKey) {
       return k.keyLabel;
     } else if (k is PhysicalKeyboardKey) {
-      final logical = KeyboardMap.current().getLogicalKeyForPhysicalKey(k);
+      // on macOS CMD (meta) on some keyboards (SVK) resulsts in US key code.
+      // So we need to take that into account when generating labels
+      // (used for key equivalents on NSMenuItem) otherwise the shortcut won't
+      // be matched.
+      final logical =
+          KeyboardMap.current().getLogicalKeyForPhysicalKey(k, meta: meta);
       if (logical != null) {
         return logical.keyLabel;
       }

--- a/nativeshell_dart/lib/src/accelerators.dart
+++ b/nativeshell_dart/lib/src/accelerators.dart
@@ -9,36 +9,35 @@ final cmdOrCtrl = _cmdOrCtrl();
 final shift = Accelerator(shift: true);
 final noModifier = Accelerator();
 
-final f1 = _accelerator(LogicalKeyboardKey.f1, 'F1');
-final f2 = _accelerator(LogicalKeyboardKey.f2, 'F2');
-final f3 = _accelerator(LogicalKeyboardKey.f3, 'F3');
-final f4 = _accelerator(LogicalKeyboardKey.f4, 'F4');
-final f5 = _accelerator(LogicalKeyboardKey.f5, 'F5');
-final f6 = _accelerator(LogicalKeyboardKey.f6, 'F6');
-final f7 = _accelerator(LogicalKeyboardKey.f7, 'F7');
-final f8 = _accelerator(LogicalKeyboardKey.f8, 'F8');
-final f9 = _accelerator(LogicalKeyboardKey.f9, 'F9');
-final f10 = _accelerator(LogicalKeyboardKey.f10, 'F10');
-final f11 = _accelerator(LogicalKeyboardKey.f11, 'F11');
-final f12 = _accelerator(LogicalKeyboardKey.f12, 'F12');
-final home = _accelerator(LogicalKeyboardKey.home, 'Home');
-final end = _accelerator(LogicalKeyboardKey.end, 'End');
-final insert = _accelerator(LogicalKeyboardKey.insert, 'Insert');
-final delete = _accelerator(LogicalKeyboardKey.delete, 'Delete');
-final backspace = _accelerator(LogicalKeyboardKey.backspace, 'Backspace');
-final pageUp = _accelerator(LogicalKeyboardKey.pageUp, 'Page Up');
-final pageDown = _accelerator(LogicalKeyboardKey.pageDown, 'Page Down');
-final space = _accelerator(LogicalKeyboardKey.space, 'Space');
-final tab = _accelerator(LogicalKeyboardKey.tab, 'Tab');
-final enter = _accelerator(LogicalKeyboardKey.enter, 'Enter');
-final upArrow = _accelerator(LogicalKeyboardKey.arrowUp, 'Up Arrow');
-final downArrow = _accelerator(LogicalKeyboardKey.arrowDown, 'Down Arrow');
-final leftArrow = _accelerator(LogicalKeyboardKey.arrowLeft, 'Left Arrow');
-final rightArrow = _accelerator(LogicalKeyboardKey.arrowRight, 'Right Arrow');
+final f1 = _accelerator(LogicalKeyboardKey.f1);
+final f2 = _accelerator(LogicalKeyboardKey.f2);
+final f3 = _accelerator(LogicalKeyboardKey.f3);
+final f4 = _accelerator(LogicalKeyboardKey.f4);
+final f5 = _accelerator(LogicalKeyboardKey.f5);
+final f6 = _accelerator(LogicalKeyboardKey.f6);
+final f7 = _accelerator(LogicalKeyboardKey.f7);
+final f8 = _accelerator(LogicalKeyboardKey.f8);
+final f9 = _accelerator(LogicalKeyboardKey.f9);
+final f10 = _accelerator(LogicalKeyboardKey.f10);
+final f11 = _accelerator(LogicalKeyboardKey.f11);
+final f12 = _accelerator(LogicalKeyboardKey.f12);
+final home = _accelerator(LogicalKeyboardKey.home);
+final end = _accelerator(LogicalKeyboardKey.end);
+final insert = _accelerator(LogicalKeyboardKey.insert);
+final delete = _accelerator(LogicalKeyboardKey.delete);
+final backspace = _accelerator(LogicalKeyboardKey.backspace);
+final pageUp = _accelerator(LogicalKeyboardKey.pageUp);
+final pageDown = _accelerator(LogicalKeyboardKey.pageDown);
+final space = _accelerator(LogicalKeyboardKey.space);
+final tab = _accelerator(LogicalKeyboardKey.tab);
+final enter = _accelerator(LogicalKeyboardKey.enter);
+final arrowUp = _accelerator(LogicalKeyboardKey.arrowUp);
+final arrowDown = _accelerator(LogicalKeyboardKey.arrowDown);
+final arrowLeft = _accelerator(LogicalKeyboardKey.arrowLeft);
+final arrowRight = _accelerator(LogicalKeyboardKey.arrowRight);
 
 Accelerator _cmdOrCtrl() {
   return Accelerator(meta: Platform.isMacOS, control: !Platform.isMacOS);
 }
 
-Accelerator _accelerator(LogicalKeyboardKey key, String description) =>
-    Accelerator(key: AcceleratorKey(key, description));
+Accelerator _accelerator(LogicalKeyboardKey key) => Accelerator(key: key);

--- a/nativeshell_dart/lib/src/api_model_internal.dart
+++ b/nativeshell_dart/lib/src/api_model_internal.dart
@@ -104,6 +104,7 @@ class KeyboardKey {
     this.logicalShift,
     this.logicalAlt,
     this.logicalAltShift,
+    this.logicalMeta,
   });
 
   final int platform;
@@ -112,6 +113,7 @@ class KeyboardKey {
   final int? logicalShift;
   final int? logicalAlt;
   final int? logicalAltShift;
+  final int? logicalMeta;
 
   static KeyboardKey deserialize(dynamic value) {
     final map = value as Map;
@@ -121,7 +123,8 @@ class KeyboardKey {
         logical: map['logical'],
         logicalShift: map['logicalShift'],
         logicalAlt: map['logicalAlt'],
-        logicalAltShift: map['logicalAltShift']);
+        logicalAltShift: map['logicalAltShift'],
+        logicalMeta: map['logicalMeta']);
   }
 }
 

--- a/nativeshell_dart/lib/src/keyboard_map.dart
+++ b/nativeshell_dart/lib/src/keyboard_map.dart
@@ -36,6 +36,7 @@ class KeyboardMap {
     PhysicalKeyboardKey physicalKey, {
     bool shift = false,
     bool alt = false,
+    bool meta = false,
   }) {
     final key = _physicalToKey[physicalKey.usbHidUsage];
 
@@ -43,7 +44,9 @@ class KeyboardMap {
       return null;
     }
 
-    if (shift && alt && key.logicalAltShift != null) {
+    if (meta && key.logicalMeta != null) {
+      return LogicalKeyboardKey(key.logicalMeta!);
+    } else if (shift && alt && key.logicalAltShift != null) {
       return LogicalKeyboardKey(key.logicalAltShift!);
     } else if (shift && !alt && key.logicalShift != null) {
       return LogicalKeyboardKey(key.logicalShift!);

--- a/nativeshell_dart/lib/src/keyboard_map_internal.dart
+++ b/nativeshell_dart/lib/src/keyboard_map_internal.dart
@@ -46,6 +46,9 @@ class KeyboardMapManager {
       if (key.logicalShift != null) {
         logicalToKey[key.logicalShift!] = key;
       }
+      if (key.logicalMeta != null) {
+        logicalToKey[key.logicalMeta!] = key;
+      }
       if (key.logical != null) {
         logicalToKey[key.logical!] = key;
       }

--- a/nativeshell_dart/lib/src/menu.dart
+++ b/nativeshell_dart/lib/src/menu.dart
@@ -122,7 +122,8 @@ class MenuItem {
           title == other.title &&
           (submenu == null) == (other.submenu == null) &&
           role == other.role &&
-          checkStatus == other.checkStatus);
+          checkStatus == other.checkStatus &&
+          accelerator == other.accelerator);
 
   @override
   int get hashCode => hashValues(title, separator, submenu != null);


### PR DESCRIPTION
When such accelerator is used in a menu, menu will automatically update on keyboard layout change to show shortcut translated to current layout.