### PR TITLE
Extract WindowLayoutProbe out of WindowWidget

### DIFF
--- a/build_test/project1/lib/main.dart
+++ b/build_test/project1/lib/main.dart
@@ -37,9 +37,11 @@ class MainWindowState extends WindowState {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.all(20),
-      child: Center(child: Text('Welcome to NativeShell!')),
+    return WindowLayoutProbe(
+      child: Container(
+        padding: EdgeInsets.all(20),
+        child: Center(child: Text('Welcome to NativeShell!')),
+      ),
     );
   }
 }

--- a/build_test/project2/lib/main.dart
+++ b/build_test/project2/lib/main.dart
@@ -37,9 +37,11 @@ class MainWindowState extends WindowState {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.all(20),
-      child: Center(child: Text('Welcome to NativeShell!')),
+    return WindowLayoutProbe(
+      child: Container(
+        padding: EdgeInsets.all(20),
+        child: Center(child: Text('Welcome to NativeShell!')),
+      ),
     );
   }
 }


### PR DESCRIPTION
This is a breaking change. It splits `WindowWidget` into `WindowWidget` and `WindowLayoutProbe`. The idea is that `WindowWidget` should be a top level widget (i.e. even above  `MaterialApp`), while `WindowLayoutProbe` should be further down in hierarchy, right above the actual content.

The reason for this is that some widgets used internally by `MaterialApp` or `Navigator`, such as `Overlay` are unable to layout unconstrained, which is necessary to measure content size when using `WindowSizingMode.sizeToContents`.