### PR TITLE
Implement `Send` for lazy_static types

### DIFF
--- a/nativeshell/src/shell/platform/macos/app_delegate.rs
+++ b/nativeshell/src/shell/platform/macos/app_delegate.rs
@@ -151,6 +151,7 @@ impl ApplicationDelegateManager {
 }
 
 struct ApplicationDelegateClass(*const Class);
+unsafe impl Send for ApplicationDelegateClass {}
 unsafe impl Sync for ApplicationDelegateClass {}
 
 lazy_static! {

--- a/nativeshell/src/shell/platform/macos/app_delegate.rs
+++ b/nativeshell/src/shell/platform/macos/app_delegate.rs
@@ -151,6 +151,7 @@ impl ApplicationDelegateManager {
 }
 
 struct ApplicationDelegateClass(*const Class);
+// Send is required when other dependencies apply the lazy_static feature 'spin_no_std'
 unsafe impl Send for ApplicationDelegateClass {}
 unsafe impl Sync for ApplicationDelegateClass {}
 

--- a/nativeshell/src/shell/platform/macos/menu.rs
+++ b/nativeshell/src/shell/platform/macos/menu.rs
@@ -536,6 +536,7 @@ impl PlatformMenu {
 
 struct MenuItemTargetClass(*const Class);
 unsafe impl Sync for MenuItemTargetClass {}
+unsafe impl Send for MenuItemTargetClass {}
 
 lazy_static! {
     static ref MENU_ITEM_TARGET_CLASS: MenuItemTargetClass = unsafe {

--- a/nativeshell/src/shell/platform/macos/menu.rs
+++ b/nativeshell/src/shell/platform/macos/menu.rs
@@ -535,8 +535,9 @@ impl PlatformMenu {
 }
 
 struct MenuItemTargetClass(*const Class);
-unsafe impl Sync for MenuItemTargetClass {}
+// Send is required when other dependencies apply the lazy_static feature 'spin_no_std'
 unsafe impl Send for MenuItemTargetClass {}
+unsafe impl Sync for MenuItemTargetClass {}
 
 lazy_static! {
     static ref MENU_ITEM_TARGET_CLASS: MenuItemTargetClass = unsafe {

--- a/nativeshell/src/shell/platform/macos/window.rs
+++ b/nativeshell/src/shell/platform/macos/window.rs
@@ -918,11 +918,13 @@ impl PlatformWindow {
 }
 
 struct WindowClass(*const Class);
-unsafe impl Sync for WindowClass {}
+// Send is required when other dependencies apply the lazy_static feature 'spin_no_std'
 unsafe impl Send for WindowClass {}
+unsafe impl Sync for WindowClass {}
 struct WindowDelegateClass(*const Class);
-unsafe impl Sync for WindowDelegateClass {}
+// Send is required when other dependencies apply the lazy_static feature 'spin_no_std'
 unsafe impl Send for WindowDelegateClass {}
+unsafe impl Sync for WindowDelegateClass {}
 
 lazy_static! {
     static ref WINDOW_CLASS: WindowClass = unsafe {

--- a/nativeshell/src/shell/platform/macos/window.rs
+++ b/nativeshell/src/shell/platform/macos/window.rs
@@ -919,8 +919,10 @@ impl PlatformWindow {
 
 struct WindowClass(*const Class);
 unsafe impl Sync for WindowClass {}
+unsafe impl Send for WindowClass {}
 struct WindowDelegateClass(*const Class);
 unsafe impl Sync for WindowDelegateClass {}
+unsafe impl Send for WindowDelegateClass {}
 
 lazy_static! {
     static ref WINDOW_CLASS: WindowClass = unsafe {

--- a/nativeshell/src/shell/platform/win32/window_adapter.rs
+++ b/nativeshell/src/shell/platform/win32/window_adapter.rs
@@ -9,6 +9,7 @@ struct Global {
     window_class: RefCell<Weak<WindowClass>>,
 }
 
+// Send is required when other dependencies apply the lazy_static feature 'spin_no_std'
 unsafe impl Send for Global {}
 unsafe impl Sync for Global {}
 

--- a/nativeshell/src/shell/platform/win32/window_adapter.rs
+++ b/nativeshell/src/shell/platform/win32/window_adapter.rs
@@ -9,6 +9,7 @@ struct Global {
     window_class: RefCell<Weak<WindowClass>>,
 }
 
+unsafe impl Send for Global {}
 unsafe impl Sync for Global {}
 
 lazy_static! {


### PR DESCRIPTION
Implement `Send` for lazy_static types. This is required if the lazy_static feature `spin_no_std` is enabled: if *any* crate enables it, then globally all lazy statics will use the feature.