### PR TITLE
Remove hand-rolled COM implementations for DnD

### DIFF
--- a/nativeshell/Cargo.toml
+++ b/nativeshell/Cargo.toml
@@ -42,7 +42,7 @@ url = "2.2.1"
 cc = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = "0.19"
+windows = "0.21.1"
 utf16_lit = "2.0.1"
 const-cstr = "0.3.0"
 widestring = "0.4.3"
@@ -51,7 +51,7 @@ detour = {version = "0.8.0", default-features = false }
 base64 = "0.13.0"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
-windows = "0.19"
+windows = "0.21.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 glib = "0.14.0"

--- a/nativeshell/build.rs
+++ b/nativeshell/build.rs
@@ -69,7 +69,7 @@ fn main() {
                 SetFocus, EnableWindow, IsWindowEnabled, SetActiveWindow, ReleaseCapture, SetCapture,
                 GetCapture, GetAsyncKeyState, GetKeyboardState, GetKeyState, TrackMouseEvent, ToUnicode,
                 ToUnicodeEx, MapVirtualKeyW, ToAscii, GetKeyboardLayout, GetKeyboardLayoutList, RegisterHotKey,
-                UnregisterHotKey, TRACKMOUSEEVENT,
+                UnregisterHotKey, TRACKMOUSEEVENT, VIRTUAL_KEY,
             },
             Windows::Win32::UI::Shell::{
                 SetWindowSubclass, RemoveWindowSubclass, DefSubclassProc, IDropTargetHelper, IDragSourceHelper,
@@ -104,9 +104,9 @@ fn main() {
                 CREATESTRUCTW, MSG, WINDOWPOS, NCCALCSIZE_PARAMS,
                 // Constants
                 TRACK_POPUP_MENU_FLAGS, WINDOW_LONG_PTR_INDEX,
-                VK_SHIFT, VK_MENU, VK_CONTROL, VK_SPACE, WNDCLASS_STYLES, IDC_ARROW, SC_CLOSE, HTCAPTION, HTTOPLEFT,
+                WNDCLASS_STYLES, IDC_ARROW, SC_CLOSE, HTCAPTION, HTTOPLEFT,
                 HTTOPRIGHT, HTTOP, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTBOTTOM, HTLEFT, HTRIGHT, HTCLIENT, HTTRANSPARENT,
-                MSGF_MENU, VK_DOWN, VK_RIGHT, VK_LEFT, MAPVK_VK_TO_VSC, MAPVK_VSC_TO_VK, MAPVK_VK_TO_CHAR,
+                MSGF_MENU, MAPVK_VK_TO_VSC, MAPVK_VSC_TO_VK, MAPVK_VK_TO_CHAR,
             },
         );
     }

--- a/nativeshell/src/shell/platform/win32/window_adapter.rs
+++ b/nativeshell/src/shell/platform/win32/window_adapter.rs
@@ -46,7 +46,7 @@ impl WindowClass {
 
     fn register(&mut self) {
         unsafe {
-            let mut class_name: Param<PWSTR> = self.class_name.clone().into_param();
+            let class_name: Param<PWSTR> = self.class_name.clone().into_param();
             let class = WNDCLASSW {
                 style: CS_HREDRAW | CS_VREDRAW,
                 lpfnWndProc: Some(wnd_proc),

--- a/nativeshell/src/shell/platform/win32/window_menu.rs
+++ b/nativeshell/src/shell/platform/win32/window_menu.rs
@@ -253,7 +253,7 @@ impl WindowMenu {
             SendMessageW(
                 menu_hwnd,
                 WM_KEYDOWN as u32,
-                WPARAM(VK_DOWN as usize),
+                WPARAM(VK_DOWN.0 as usize),
                 LPARAM(0),
             );
             let mut item_info = MENUITEMINFOW {
@@ -359,8 +359,8 @@ impl WindowMenu {
             let key = msg.wParam.0 as u32;
 
             let (key_prev, key_next) = match self.delegate().get_state().is_rtl() {
-                true => (VK_RIGHT, VK_LEFT),
-                false => (VK_LEFT, VK_RIGHT),
+                true => (VK_RIGHT.0 as u32, VK_LEFT.0 as u32),
+                false => (VK_LEFT.0 as u32, VK_RIGHT.0 as u32),
             };
 
             if let Some(delegate) = current_menu.platform_menu.delegate.upgrade() {


### PR DESCRIPTION
With current window-rs version the `implement` macro can finally do all the magic we need!