### PR TITLE
Don't qualify macros when including file

### DIFF
--- a/nativeshell/src/shell/platform/macos/keyboard_map.rs
+++ b/nativeshell/src/shell/platform/macos/keyboard_map.rs
@@ -40,10 +40,7 @@ pub struct PlatformKeyboardMap {
     delegate: Weak<RefCell<dyn KeyboardMapDelegate>>,
 }
 
-include!(std::concat!(
-    std::env!("OUT_DIR"),
-    "/generated_keyboard_map.rs"
-));
+include!(concat!(env!("OUT_DIR"), "/generated_keyboard_map.rs"));
 
 impl PlatformKeyboardMap {
     pub fn new(_context: Context, delegate: Weak<RefCell<dyn KeyboardMapDelegate>>) -> Self {

--- a/nativeshell/src/shell/platform/win32/keyboard_map.rs
+++ b/nativeshell/src/shell/platform/win32/keyboard_map.rs
@@ -23,10 +23,7 @@ pub struct PlatformKeyboardMap {
     delegate: Weak<RefCell<dyn KeyboardMapDelegate>>,
 }
 
-include!(std::concat!(
-    std::env!("OUT_DIR"),
-    "/generated_keyboard_map.rs"
-));
+include!(concat!(env!("OUT_DIR"), "/generated_keyboard_map.rs"));
 
 impl PlatformKeyboardMap {
     pub fn new(_context: Context, delegate: Weak<RefCell<dyn KeyboardMapDelegate>>) -> Self {


### PR DESCRIPTION
This works around a bug in rust-analyzer (https://github.com/rust-analyzer/rust-analyzer/issues/10550) and allows IDE functionality to work.