### PR TITLE
Ignore unnecessary_non_null_assertion warnings when accessing bindings

### DIFF
--- a/nativeshell_dart/lib/src/drag_drop.dart
+++ b/nativeshell_dart/lib/src/drag_drop.dart
@@ -421,6 +421,7 @@ class DragDriver {
     _RenderDropRegion? dropRegion;
     final monitors = <_RenderDropMonitor>[];
 
+    // ignore: unnecessary_non_null_assertion
     GestureBinding.instance!.hitTest(hitTest, info.position);
 
     for (final item in hitTest.path) {

--- a/nativeshell_dart/lib/src/key_interceptor.dart
+++ b/nativeshell_dart/lib/src/key_interceptor.dart
@@ -12,7 +12,9 @@ class KeyInterceptor {
   KeyInterceptor._() {
     WidgetsFlutterBinding.ensureInitialized();
     _previousHandler =
+        // ignore: unnecessary_non_null_assertion
         ServicesBinding.instance!.keyEventManager.keyMessageHandler;
+    // ignore: unnecessary_non_null_assertion
     ServicesBinding.instance!.keyEventManager.keyMessageHandler = _onMessage;
   }
 

--- a/nativeshell_dart/lib/src/window_manager.dart
+++ b/nativeshell_dart/lib/src/window_manager.dart
@@ -178,6 +178,7 @@ int _pauseCount = 0;
 void _pushPause() {
   ++_pauseCount;
   if (_pauseCount > 0) {
+    // ignore: unnecessary_non_null_assertion
     WidgetsBinding.instance!
         .handleAppLifecycleStateChanged(AppLifecycleState.paused);
   }
@@ -187,6 +188,7 @@ void _popPause() {
   assert(_pauseCount > 0);
   --_pauseCount;
   if (_pauseCount == 0) {
+    // ignore: unnecessary_non_null_assertion
     WidgetsBinding.instance!
         .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
   }

--- a/nativeshell_dart/lib/src/window_method_channel.dart
+++ b/nativeshell_dart/lib/src/window_method_channel.dart
@@ -42,6 +42,7 @@ class WindowMethodDispatcher {
 
   final MessageCodec _codec;
   BinaryMessenger get _binaryMessenger =>
+      // ignore: unnecessary_non_null_assertion
       ServicesBinding.instance!.defaultBinaryMessenger;
 
   Future<T> invokeMethod<T>({

--- a/nativeshell_dart/lib/src/window_widget.dart
+++ b/nativeshell_dart/lib/src/window_widget.dart
@@ -177,6 +177,7 @@ class _WindowWidgetState extends State<WindowWidget> {
         WindowManager.instance.haveWindowState(_windowState!);
       }
       if (_windowState!.windowSizingMode == WindowSizingMode.manual) {
+        // ignore: unnecessary_non_null_assertion
         WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
           _prepareAndShow(_windowState!, () => Size(0, 0));
         });
@@ -485,6 +486,7 @@ Size _sanitizeAndSnapToPixelBoundary(Size size) {
   }
   size = Size(w, h);
 
+  // ignore: unnecessary_non_null_assertion
   final ratio = WidgetsBinding.instance!.window.devicePixelRatio;
   size = size * ratio;
   size = Size(size.width.ceilToDouble(), size.height.ceilToDouble());


### PR DESCRIPTION
Needed to work with both stable and master.