### PR TITLE
Fix cross compile.

### DIFF
--- a/nativeshell/Cargo.toml
+++ b/nativeshell/Cargo.toml
@@ -22,6 +22,7 @@ once_cell = "1.8.0"
 
 [build-dependencies]
 cargo-emit = "0.2.1"
+cc = "1.0"
 nativeshell_build = { version="0.1.1", path = "../nativeshell_build" }
 serde = { version = "1.0.119", features = ["derive"] }
 serde_json = "1.0.59"
@@ -37,9 +38,6 @@ block = "0.1.6"
 exec = "0.3.1"
 process_path = "0.1.3"
 url = "2.2.1"
-
-[target.'cfg(target_os = "macos")'.build-dependencies]
-cc = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 utf16_lit = "2.0.1"

--- a/nativeshell/build.rs
+++ b/nativeshell/build.rs
@@ -4,8 +4,7 @@ use nativeshell_build::Flutter;
 mod gen_keyboard_map;
 
 fn main() {
-    #[cfg(target_os = "macos")]
-    {
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
         let files = ["src/shell/platform/macos/window_buttons.m"];
         let mut build = cc::Build::new();
         for file in files.iter() {


### PR DESCRIPTION
Been working on a new flutter tool that supports cross building debug artefacts for all platforms. Using nativeshell as the entry point on desktop platforms. To get nativeshell to cross compile for macos the `target_os` needs to be read from the environment variable `CARGO_CFG_TARGET_OS`, because the `target_os` in a build script is the host os not the target os.

Closes #123 