### PR TITLE
More cross fixes.

### DIFF
--- a/nativeshell/build.rs
+++ b/nativeshell/build.rs
@@ -22,4 +22,14 @@ fn main() {
 
     let target_system = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     gen_keyboard_map::generate_keyboard_map(&target_system).unwrap();
+
+    match std::env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() {
+        "linux" => println!("cargo:rustc-link-lib=flutter_linux_gtk"),
+        "macos" => {
+            println!("cargo:rustc-link-lib=framework=FlutterMacOS");
+            println!("cargo:rustc-link-arg=-rpath=@executable_path/../Frameworks");
+        }
+        "windows" => println!("cargo:rustc-link-lib=flutter_windows.dll"),
+        os => panic!("unsupported os {}", os),
+    }
 }


### PR DESCRIPTION
So was previously cross compiling from linux to all platforms. While cross compiling from macos to windows for example the build scripts pick up the framework and then fail to run as the rpath is set for the final destination. It's ok to set the search paths in `RUSTFLAGS` but linking to the actual library should be done in the build script of the crate.