### PR TITLE
Fix build on apple silicon

### DIFF
--- a/nativeshell_build/src/artifacts_emitter.rs
+++ b/nativeshell_build/src/artifacts_emitter.rs
@@ -217,13 +217,7 @@ impl<'a> ArtifactsEmitter<'a> {
             }
             None => {
                 let platform = match self.build.target_platform.as_str() {
-                    "darwin" => {
-                        let darwin_os = match self.build.darwin_arch.as_ref().unwrap().as_str() {
-                            "x86_64" => "x64",
-                            other => other,
-                        };
-                        format!("{}-{}", self.build.target_platform, darwin_os)
-                    }
+                    "darwin" => format!("{}-{}", self.build.target_platform, "x64"),
                     other => other.into(),
                 };
 

--- a/nativeshell_dart/pubspec.yaml
+++ b/nativeshell_dart/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/nativeshell/nativeshell
 
 environment:
   sdk: ">=2.13.0 <3.0.0"
-  flutter: ">=2.2.1"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR fixes build issues on Apple silicon by adding support for universal MacOS binaries that are now shipped with Flutter 3.0.0. Apple silicon users on Flutter 3 also don't need to do `cargo run --target=x86_64-apple-darwin` anymore. They can just `cargo run` like everyone else.

Closes [#164](https://github.com/nativeshell/nativeshell/issues/164)