### PR TITLE
Define acceptsFirstMouse: on FlutterView conditionally

### DIFF
--- a/nativeshell/src/shell/platform/macos/window.rs
+++ b/nativeshell/src/shell/platform/macos/window.rs
@@ -1050,10 +1050,18 @@ static WINDOW_CLASS: Lazy<&'static Class> = Lazy::new(|| unsafe {
     // FlutterView doesn't override acceptsFirstMouse: so we do it here
     {
         let mut class = class_decl_from_name("FlutterView");
-        class.add_method(
-            sel!(acceptsFirstMouse:),
-            accepts_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
-        );
+
+        let accepts_first_mouse_defined: bool = msg_send![
+            class!(FlutterView),
+            instancesRespondToSelector: sel!(acceptsFirstMouse:)
+        ];
+
+        if !accepts_first_mouse_defined {
+            class.add_method(
+                sel!(acceptsFirstMouse:),
+                accepts_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
+            );
+        }
     }
 
     let window_superclass = class!(NSWindow);


### PR DESCRIPTION
Defines `acceptsFirstMouse:` on `FlutterView` only if it doesn't already exist.

This is necessary because Flutter engine has indeed recently added an implementation of `acceptsFirstMouse:`: https://github.com/flutter/engine/pull/34093