### PR TITLE
fix(shell/linux): windows sometimes doesn't unpause after it's shown

### DIFF
--- a/nativeshell/src/shell/platform/linux/window.rs
+++ b/nativeshell/src/shell/platform/linux/window.rs
@@ -106,6 +106,9 @@ impl PlatformWindow {
 
     pub fn on_first_frame(&self) {
         self.window.set_opacity(1.0);
+        if let Some(delegate) = self.delegate.upgrade() {
+            delegate.visibility_changed(self.window.is_visible());
+        }
     }
 
     pub fn engine_launched(&self) {
@@ -381,6 +384,9 @@ impl PlatformWindow {
     pub fn show(&self) -> PlatformResult<()> {
         if self.ready_to_show.get() {
             self.window.show();
+            if let Some(delegate) = self.delegate.upgrade() {
+                delegate.visibility_changed(true);
+            }
             Ok(())
         } else {
             self.show_when_ready.set(true);


### PR DESCRIPTION
I was running my application with the rework pause logic commit (d14f387c) reverted for a while as it often didn't react to input on launch on linux.

Apparently the window never unpaused because the visibility change event wasn't emitted.
This pr fixes this issue.

Together with #223 this fixes the latest nativeshell version on linux with flutter 3.19.6.

There is still an issue with flutter 3.22+ where the window doesn't open which I'm currently investigating though.