### PR TITLE
fix(event_channel): unregister_event_sink is never called

### DIFF
--- a/nativeshell/src/shell/event_channel.rs
+++ b/nativeshell/src/shell/event_channel.rs
@@ -119,6 +119,7 @@ impl<T: EventChannelHandler> MethodCallHandler for EventChannelInternal<T> {
                 self.handler
                     .borrow_mut()
                     .register_event_sink(sink, call.args);
+                self.engine_to_sink.insert(engine, sink_id);
                 reply.send_ok(Value::Null);
             }
             "cancel" => {


### PR DESCRIPTION
When an event channel is cancelled the MethodCallHandler looks for the sink id for the current engine handle. But because the sink id is not stored while listening it will never call the unregister_event_sink method on the EventChannelHandler.